### PR TITLE
Ignore failures from databoard sanity checks on explorer launch

### DIFF
--- a/explorer/src/map.js
+++ b/explorer/src/map.js
@@ -8,7 +8,7 @@ export function initMap(center, zoom) {
 
   const mp = new mapboxgl.Map({
     container: 'map-container',
-    style: 'https://maps.tilehosting.com/styles/positron/style.json?key=dcCQFarAif6ie2xrgCEF',
+    style: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
     zoom: zoom,
     center: center,
     hash: false

--- a/tasks.py
+++ b/tasks.py
@@ -30,12 +30,12 @@ def pop_stack(ctx, build_dockers=False):
     ctx.run("docker-compose up -d")
 
 
-def _run_container(ctx, container_name, job, cosmogony_data_dir=None):
+def _run_container(ctx, container_name, job, cosmogony_data_dir=None, continue_on_fail=False):
     main_docker_files = _get_docker_compose()
     run_docker_files = {"COMPOSE_FILE": main_docker_files + ":docker-compose.run.yml"}
     if cosmogony_data_dir:
         run_docker_files['PATH_TO_COSMOGONY_DIR'] = cosmogony_data_dir
-    ctx.run(f"docker-compose run --rm {container_name} {job}", env=run_docker_files)
+    ctx.run(f"docker-compose run --rm {container_name} {job}", env=run_docker_files, warn=continue_on_fail)
 
 
 @task(default=True)
@@ -72,4 +72,5 @@ def generate_data_dashboard(ctx, cosmogony_file_name, cosmogony_data_dir):
         "data-dashboard",
         f"--cosmogony=/mnt/data/{cosmogony_file_name} --output=/mnt/data-dashboard/test_results.json",
         cosmogony_data_dir=cosmogony_data_dir,
+        continue_on_fail=True,
     )


### PR DESCRIPTION
Should fix #40 

* The errors from the data dashboard summary should not block the explorer launch
* Replace obsolete basemap URL with a style from Carto CDN

